### PR TITLE
c++编译说明以及依赖项添加

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ pip install labelme==4.5.7
 pip install opencv-python==4.5.2.52
 pip install cython
 ```
+## Compile C++ wrapper
+### Linux
+```bash
+cd labelme_local/cython
+python setup.py build_ext --inplace
+cd ..
+```
 
 ## How To Use
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ numpy>=1.20.2
 Pillow>=9.0.1
 qtpy~=1.9.0
 opencv-python~=4.5.2.54
+opencv_python_headless~=4.5.2.54
 pyyaml~=5.4.1
 cython~=0.29.24
 termcolor~=1.1.0


### PR DESCRIPTION
添加了linux下编译c++包的命令（应该也适用于windows，但是没测试），可以方便在不同环境下运行软件
依赖项中添加了opencv_python_headless，可以解决找不到qt包的问题